### PR TITLE
Rag fusion rw 002 vector database

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,16 @@
 import os
 import openai
 import random
+import chromadb
+
 
 # Initialize OpenAI API
 openai.api_key = os.getenv("OPENAI_API_KEY")  # Alternative: Use environment variable
 if openai.api_key is None:
     raise Exception("No OpenAI API key found. Please set it as an environment variable or in main.py")
+
+# Initialize ChromeDB
+chroma_client = chromadb.Client()
 
 # Function to generate queries using OpenAI's ChatGPT
 def generate_queries_chatgpt(original_query):
@@ -22,13 +27,21 @@ def generate_queries_chatgpt(original_query):
     generated_queries = response.choices[0]["message"]["content"].strip().split("\n")
     return generated_queries
 
-# Mock function to simulate vector search, returning random scores
-def vector_search(query, all_documents):
-    available_docs = list(all_documents.keys())
-    random.shuffle(available_docs)
-    selected_docs = available_docs[:random.randint(2, 5)]
-    scores = {doc: round(random.uniform(0.7, 0.9), 2) for doc in selected_docs}
-    return {doc: score for doc, score in sorted(scores.items(), key=lambda x: x[1], reverse=True)}
+# Function to perform a vector search, returning random scores
+def vector_search(query, collection):
+    # Perform the Chroma vector search for the given query
+    chroma_results = collection.query(
+        query_texts=[query],
+        n_results=4  # Adjust the number of results as needed
+    )
+
+    # Extract the relevant document texts from Chroma results
+    chroma_doc_texts = [result for result in chroma_results]
+
+    # Assign random scores to each document from Chroma results
+    scores = {doc_text: round(random.uniform(0.7, 0.9), 2) for doc_text in chroma_doc_texts}
+
+    return scores
 
 # Reciprocal Rank Fusion algorithm
 def reciprocal_rank_fusion(search_results_dict, k=60):
@@ -53,29 +66,66 @@ def reciprocal_rank_fusion(search_results_dict, k=60):
 def generate_output(reranked_results, queries):
     return f"Final output based on {queries} and reranked documents: {list(reranked_results.keys())}"
 
+# Chroma: Create Collection in this case "all_documents"
+collection = chroma_client.create_collection(name="all_documents")
 
+#################################
 # Predefined set of documents (usually these would be from your search database)
-all_documents = {
-    "doc1": "Climate change and economic impact.",
-    "doc2": "Public health concerns due to climate change.",
-    "doc3": "Climate change: A social perspective.",
-    "doc4": "Technological solutions to climate change.",
-    "doc5": "Policy changes needed to combat climate change.",
-    "doc6": "Climate change and its impact on biodiversity.",
-    "doc7": "Climate change: The science and models.",
-    "doc8": "Global warming: A subset of climate change.",
-    "doc9": "How climate change affects daily weather.",
-    "doc10": "The history of climate change activism."
-}
+## Replaced the "all_documents" section with the below chroma collection.
+#################################
+
+#Add some text documents to the collection
+#Chroma will store your text, and handle tokenization, embedding, and indexing automatically.
+collection.add(
+    documents=[
+        "Climate change and economic impact. Addressing climate change can be challenging, but by investing in sustainable technologies and policies, we can mitigate its economic impact and build a greener, more resilient future.",
+        "Public health concerns due to climate change. Addressing public health concerns linked to climate change is feasible through proactive measures like improved healthcare infrastructure, climate adaptation, and public awareness campaigns.",
+        "Climate change: A social perspective. Understanding climate change from a social perspective is possible. It requires fostering a sense of collective responsibility, promoting eco-friendly behaviors, and equitable climate policies for a sustainable future.",
+        "Technological solutions to climate change. Implementing technological solutions to combat climate change is both possible and promising. Advancements in renewable energy, carbon capture, and sustainable agriculture offer hope for a greener future.",
+        "Policy changes needed to combat climate change. Making policy changes to combat climate change is not impossible but rather necessary. Governments worldwide can enact laws to reduce emissions, promote renewable energy, and incentivize sustainable practices for a greener planet.",
+        "Climate change and its impact on biodiversity. Addressing the impact of climate change on biodiversity is vital. Conservation efforts, habitat restoration, and global cooperation can help protect threatened species and ecosystems from further harm.",
+        "Climate change: The science and models. Understanding climate change through science and models is entirely possible. Researchers use data, simulations, and predictive models to study and anticipate climate trends, providing valuable insights for mitigation and adaptation strategies.",
+        "Global warming: A subset of climate change. Yes, global warming is a subset of climate change. It specifically refers to the long-term increase in Earth's average surface temperature, which is a key aspect of the broader phenomenon of climate change.",
+        "How climate change affects daily weather. Climate change can influence daily weather patterns, making certain extreme events more frequent. While not impossible to explain, it's a complex process involving shifts in atmospheric circulation and temperature, which scientists study to better understand and predict weather changes.",
+        "The history of climate change activism. The history of climate change activism is rich and inspiring. It began with grassroots movements and evolved into a global force for environmental awareness and policy change, demonstrating the power of collective action."
+    ],
+    metadatas=[
+        {"source": "documents1"},
+        {"source": "documents2"},
+        {"source": "documents3"},
+        {"source": "documents4"},
+        {"source": "documents5"},
+        {"source": "documents6"},
+        {"source": "documents7"},
+        {"source": "documents8"},
+        {"source": "documents9"},
+        {"source": "documents10"}
+    ],
+    ids=[
+        "doc1",
+        "doc2",
+        "doc3",
+        "doc4",
+        "doc5",
+        "doc6",
+        "doc7",
+        "doc8",
+        "doc9",
+        "doc10"
+    ]
+)
+
 
 # Main function
 if __name__ == "__main__":
+    # Define your Chroma collection and other necessary configurations here
+
     original_query = "impact of climate change"
     generated_queries = generate_queries_chatgpt(original_query)
     
     all_results = {}
     for query in generated_queries:
-        search_results = vector_search(query, all_documents)
+        search_results = vector_search(query, collection)  # Use the modified vector_search() function
         all_results[query] = search_results
     
     reranked_results = reciprocal_rank_fusion(all_results)

--- a/main.py
+++ b/main.py
@@ -40,18 +40,14 @@ def vector_search(query, collection):
     n_results=4
   )
   logging.info(f"chroma_results: {chroma_results}")
-  logging.info(f"##############################################")
   
   # Extract document IDs (flattened)
   document_ids = chroma_results['ids'][0]  
   logging.info(f"document_ids: {document_ids}")
-  logging.info(f"##############################################")
 
   # Retrieve documents
   chroma_doc_texts = []
   chroma_doc_metadata = []
-  # logging.info(f"chroma_doc_texts: {chroma_doc_texts}")
-  # logging.info(f"chroma_doc_metadata: {chroma_doc_metadata}")
   # Initialize metadatas as a list
   metadatas = []
   documents = []  
@@ -61,15 +57,13 @@ def vector_search(query, collection):
     logging.info(f"doc_info 56: {doc_info}")
 
     if doc_info:
-      #chroma_doc_texts.append(doc_info[0]['documents'])
-      #chroma_doc_metadata.append(doc_info[0]['metadata'])
+
       chroma_doc_texts.append(doc_info['documents'][0])
       chroma_doc_metadata.append(doc_info['metadatas'][0])
       metadata = doc_info['metadatas'][0] 
       metadatas.append(metadata)
       document = doc_info['documents'][0]
       documents.append(document)
-
 
     else:
       chroma_doc_texts.append("Document not found")
@@ -80,7 +74,7 @@ def vector_search(query, collection):
   # Extract titles 
   document_titles = [metadata.get("title", "Unknown Title") for metadata in chroma_doc_metadata]
   logging.info(f"document_titles: {document_titles}")
-  logging.info(f"##################document_titles: {document_titles}")
+
   # Generate scores dict
   scores_dict = {
     doc_id: round(random.uniform(0.7, 0.9), 2) for doc_id in document_ids
@@ -98,16 +92,12 @@ def vector_search(query, collection):
   #documents = [doc_info['documents'][0][0] for doc_info in collection.get(document_ids)]
   logging.info(f"################## documents: {documents}")
 
-  logging.info(f"scores: {scores}")  
-  logging.info(f"############# Vector Search Output #################################")
+  logging.info(f"scores: {scores}")
 
   # Log results
   logging.info(f"scores: {scores}")
   logging.info(f"document_ids: {document_ids}")
-  logging.info(f"##############################################")
 
-  #return scores, score_values, document_ids
-  #return scores, score_values, document_ids, metadatas
   return scores, score_values, document_ids, metadatas, documents
 
 # Reciprocal Rank Fusion algorithm
@@ -117,23 +107,15 @@ def reciprocal_rank_fusion(all_results, document_ids, k=60):
 
   #for query, doc_scores in search_results_dict.items():
   for query, result in all_results.items():
-
     logging.info(f"For query '{query}': {result}")
-    
-    #score_values = list(doc_scores.values())
     score_values = result["score_values"]
 
-    for rank, score in enumerate(sorted(score_values)):
-    
-      doc_id = document_ids[rank]
-      
+    for rank, score in enumerate(sorted(score_values)):    
+      doc_id = document_ids[rank]      
       if doc_id not in fused_scores:
-        fused_scores[doc_id] = 0
-        
-      previous_score = fused_scores[doc_id]
-      
-      fused_scores[doc_id] += 1 / (rank + k)
-      
+        fused_scores[doc_id] = 0        
+      previous_score = fused_scores[doc_id]      
+      fused_scores[doc_id] += 1 / (rank + k)      
       logging.info(f"Updating score for {doc_id} from {previous_score} to {fused_scores[doc_id]} based on rank {rank} in query '{query}'")
 
   reranked_results = {doc_id: score for doc_id, score in sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)}
@@ -146,25 +128,13 @@ def generate_output(reranked_results, queries, metadatas, documents):
     # Extract the top-ranked document ID and its score
     top_document_id, top_score = next(iter(reranked_results.items()))
 
-    # Fetch the actual document title associated with the document ID
-    #top_document_title = document_titles.get(top_document_id, "Unknown Title")
-    logging.info(f"###################metadata###########################")    
+    # Fetch the actual document title associated with the document ID 
     logging.info(f"metadatas: {metadatas}")
-    logging.info(f"##############################################")
     top_doc_index = document_ids.index(top_document_id)
     logging.info(f"top_doc_index: {top_doc_index}")
     top_doc_metadata = metadatas[top_doc_index]
-
     logging.info(f"top_doc_metadata: {top_doc_metadata}")
-
-    #logging.info(f"metadatas: {metadatas[top_document_id]}")
-    #top_document_metadata = metadatas[top_document_id]
-    #top_document_title = top_document_metadata.get("title", "Unknown Title")
     top_document_title = top_doc_metadata.get("title", "Unknown Title")
-    
-
-    #top_document_title = metadatas.get(top_document_id, {}).get("title", "Unknown Title")
-
 
     # Generate_summary() generates a summary for the top document
     document_summary = generate_summary(top_document_id, metadatas, documents)  # Implement this function
@@ -191,7 +161,7 @@ collection = chroma_client.create_collection(name="all_documents")
 ## Replaced the "all_documents" section with the below chroma collection.
 #################################
 
-#Add some text documents to the collection
+#Added some text documents to the collection
 #Chroma will store your text, and handle tokenization, embedding, and indexing automatically.
 collection.add(
     documents=[
@@ -235,9 +205,9 @@ collection.add(
 def generate_summary(document_id, metadatas, documents):
     # Lookup document text
     doc_index = document_ids.index(document_id)
-    logging.info(f"meta_data gensummm: {metadatas}")
+    logging.info(f"meta_data: {metadatas}")
     logging.info(f"documents: {documents}")
-    #doc_text = metadatas[doc_index]['text']
+
     # Define the prompt for generating the summary
     prompt = f"Summarize the following document:\n{documents}\n\nSummary:"
 
@@ -251,23 +221,19 @@ def generate_summary(document_id, metadatas, documents):
     )
 
     # Extract the generated summary from the response
-    summary = response.choices[0].text.strip()
-    
+    summary = response.choices[0].text.strip()    
     return summary
 
 # Main function
 if __name__ == "__main__":
     # Define your Chroma collection and other necessary configurations here
-
     original_query = "impact of climate change"
     generated_queries = generate_queries_chatgpt(original_query)
     
     all_results = {}
     for query in generated_queries:
 
-      #scores, score_values, document_ids = vector_search(query, collection)
       scores, score_values, document_ids, metadatas, documents= vector_search(query, collection)
-
       
       all_results[query] = {
         "scores": scores,
@@ -275,19 +241,9 @@ if __name__ == "__main__":
       }
     
     logging.info(f"all_results: {all_results}")
-    logging.info(f"##############################################")
-    #reranked_results = reciprocal_rank_fusion(all_results)
     reranked_results = reciprocal_rank_fusion(all_results, document_ids)
-    logging.info(f"##############################################")
-    print("Final reranked results <bottom>:", reranked_results)
-    logging.info(f"##############################################")    
+    print("Final reranked results <bottom>:", reranked_results)  
     
-    #final_output = generate_output(reranked_results, generated_queries)
-    #final_output = generate_output(reranked_results, generated_queries, document_titles)
     final_output = generate_output(reranked_results, generated_queries, metadatas, documents)
-    #final_output = generate_output(reranked_results, generated_queries, metadatas)
-
-
-
     
     print(final_output)

--- a/main.py
+++ b/main.py
@@ -2,6 +2,10 @@ import os
 import openai
 import random
 import chromadb
+import logging
+
+# Initialize logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s', datefmt='%Y-%m-%d %H:%M:%S',filename='/tmp/ragfusion.log', filemode='w')
 
 
 # Initialize OpenAI API
@@ -29,42 +33,155 @@ def generate_queries_chatgpt(original_query):
 
 # Function to perform a vector search, returning random scores
 def vector_search(query, collection):
-    # Perform the Chroma vector search for the given query
-    chroma_results = collection.query(
-        query_texts=[query],
-        n_results=4  # Adjust the number of results as needed
-    )
 
-    # Extract the relevant document texts from Chroma results
-    chroma_doc_texts = [result for result in chroma_results]
+  # Perform vector search
+  chroma_results = collection.query(
+    query_texts=[query],  
+    n_results=4
+  )
+  logging.info(f"chroma_results: {chroma_results}")
+  logging.info(f"##############################################")
+  
+  # Extract document IDs (flattened)
+  document_ids = chroma_results['ids'][0]  
+  logging.info(f"document_ids: {document_ids}")
+  logging.info(f"##############################################")
 
-    # Assign random scores to each document from Chroma results
-    scores = {doc_text: round(random.uniform(0.7, 0.9), 2) for doc_text in chroma_doc_texts}
+  # Retrieve documents
+  chroma_doc_texts = []
+  chroma_doc_metadata = []
+  # logging.info(f"chroma_doc_texts: {chroma_doc_texts}")
+  # logging.info(f"chroma_doc_metadata: {chroma_doc_metadata}")
+  # Initialize metadatas as a list
+  metadatas = []
+  documents = []  
 
-    return scores
+  for doc_id in document_ids:
+    doc_info = collection.get(ids=[doc_id])
+    logging.info(f"doc_info 56: {doc_info}")
+
+    if doc_info:
+      #chroma_doc_texts.append(doc_info[0]['documents'])
+      #chroma_doc_metadata.append(doc_info[0]['metadata'])
+      chroma_doc_texts.append(doc_info['documents'][0])
+      chroma_doc_metadata.append(doc_info['metadatas'][0])
+      metadata = doc_info['metadatas'][0] 
+      metadatas.append(metadata)
+      document = doc_info['documents'][0]
+      documents.append(document)
+
+
+    else:
+      chroma_doc_texts.append("Document not found")
+      chroma_doc_metadata.append({})
+
+  document_ids = chroma_results['ids'][0]
+  logging.info(f"document_ids: {document_ids}")
+  # Extract titles 
+  document_titles = [metadata.get("title", "Unknown Title") for metadata in chroma_doc_metadata]
+  logging.info(f"document_titles: {document_titles}")
+  logging.info(f"##################document_titles: {document_titles}")
+  # Generate scores dict
+  scores_dict = {
+    doc_id: round(random.uniform(0.7, 0.9), 2) for doc_id in document_ids
+  }
+  # Create scores
+  scores = {
+    "text": chroma_doc_texts,
+    "titles": document_titles, 
+    "scores": scores_dict
+  }
+  logging.info(f"################## doc_info: {doc_info}")
+  # Extract just the score values into a list 
+  score_values = list(scores_dict.values())
+  # Also build documents list
+  #documents = [doc_info['documents'][0][0] for doc_info in collection.get(document_ids)]
+  logging.info(f"################## documents: {documents}")
+
+  logging.info(f"scores: {scores}")  
+  logging.info(f"############# Vector Search Output #################################")
+
+  # Log results
+  logging.info(f"scores: {scores}")
+  logging.info(f"document_ids: {document_ids}")
+  logging.info(f"##############################################")
+
+  #return scores, score_values, document_ids
+  #return scores, score_values, document_ids, metadatas
+  return scores, score_values, document_ids, metadatas, documents
 
 # Reciprocal Rank Fusion algorithm
-def reciprocal_rank_fusion(search_results_dict, k=60):
-    fused_scores = {}
-    print("Initial individual search result ranks:")
-    for query, doc_scores in search_results_dict.items():
-        print(f"For query '{query}': {doc_scores}")
+def reciprocal_rank_fusion(all_results, document_ids, k=60):
+
+  fused_scores = {}
+
+  #for query, doc_scores in search_results_dict.items():
+  for query, result in all_results.items():
+
+    logging.info(f"For query '{query}': {result}")
+    
+    #score_values = list(doc_scores.values())
+    score_values = result["score_values"]
+
+    for rank, score in enumerate(sorted(score_values)):
+    
+      doc_id = document_ids[rank]
+      
+      if doc_id not in fused_scores:
+        fused_scores[doc_id] = 0
         
-    for query, doc_scores in search_results_dict.items():
-        for rank, (doc, score) in enumerate(sorted(doc_scores.items(), key=lambda x: x[1], reverse=True)):
-            if doc not in fused_scores:
-                fused_scores[doc] = 0
-            previous_score = fused_scores[doc]
-            fused_scores[doc] += 1 / (rank + k)
-            print(f"Updating score for {doc} from {previous_score} to {fused_scores[doc]} based on rank {rank} in query '{query}'")
+      previous_score = fused_scores[doc_id]
+      
+      fused_scores[doc_id] += 1 / (rank + k)
+      
+      logging.info(f"Updating score for {doc_id} from {previous_score} to {fused_scores[doc_id]} based on rank {rank} in query '{query}'")
 
-    reranked_results = {doc: score for doc, score in sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)}
-    print("Final reranked results:", reranked_results)
-    return reranked_results
+  reranked_results = {doc_id: score for doc_id, score in sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)}
+  
+  print("Final reranked results:", reranked_results)
 
-# Dummy function to simulate generative output
-def generate_output(reranked_results, queries):
-    return f"Final output based on {queries} and reranked documents: {list(reranked_results.keys())}"
+  return reranked_results
+
+def generate_output(reranked_results, queries, metadatas, documents):
+    # Extract the top-ranked document ID and its score
+    top_document_id, top_score = next(iter(reranked_results.items()))
+
+    # Fetch the actual document title associated with the document ID
+    #top_document_title = document_titles.get(top_document_id, "Unknown Title")
+    logging.info(f"###################metadata###########################")    
+    logging.info(f"metadatas: {metadatas}")
+    logging.info(f"##############################################")
+    top_doc_index = document_ids.index(top_document_id)
+    logging.info(f"top_doc_index: {top_doc_index}")
+    top_doc_metadata = metadatas[top_doc_index]
+
+    logging.info(f"top_doc_metadata: {top_doc_metadata}")
+
+    #logging.info(f"metadatas: {metadatas[top_document_id]}")
+    #top_document_metadata = metadatas[top_document_id]
+    #top_document_title = top_document_metadata.get("title", "Unknown Title")
+    top_document_title = top_doc_metadata.get("title", "Unknown Title")
+    
+
+    #top_document_title = metadatas.get(top_document_id, {}).get("title", "Unknown Title")
+
+
+    # Generate_summary() generates a summary for the top document
+    document_summary = generate_summary(top_document_id, metadatas, documents)  # Implement this function
+
+    # Generate a response with the correct document title, relevance score, summary, and original queries
+    response = f"Here is the most relevant information regarding '{queries[0]}':\n\n"
+    response += f"Document Title: {top_document_title}\n"
+    response += f"Relevance Score: {top_score}\n\n"
+    response += f"Summary of the document:\n{document_summary}\n\n"
+
+    response += "Original Queries:\n"
+    for query in queries:
+        response += f"- {query}\n"
+
+    response += "\nBy layering these technologies and techniques, RAG Fusion offers a powerful, nuanced approach to text generation. It leverages the best of search technology and generative AI to produce high-quality, reliable outputs."
+
+    return response
 
 # Chroma: Create Collection in this case "all_documents"
 collection = chroma_client.create_collection(name="all_documents")
@@ -90,16 +207,16 @@ collection.add(
         "The history of climate change activism. The history of climate change activism is rich and inspiring. It began with grassroots movements and evolved into a global force for environmental awareness and policy change, demonstrating the power of collective action."
     ],
     metadatas=[
-        {"source": "documents1"},
-        {"source": "documents2"},
-        {"source": "documents3"},
-        {"source": "documents4"},
-        {"source": "documents5"},
-        {"source": "documents6"},
-        {"source": "documents7"},
-        {"source": "documents8"},
-        {"source": "documents9"},
-        {"source": "documents10"}
+        {"source": "doc1", "title": "Climate change and economic impact"},
+        {"source": "doc2", "title": "Public health concerns due to climate change"},
+        {"source": "doc3", "title": "Climate change: A social perspective"},
+        {"source": "doc4", "title": "Technological solutions to climate change"},
+        {"source": "doc5", "title": "Policy changes needed to combat climate change"},
+        {"source": "doc6", "title": "Climate change and its impact on biodiversity"},
+        {"source": "doc7", "title": "Climate change: The science and models"},
+        {"source": "doc8", "title": "Global warming: A subset of climate change"},
+        {"source": "doc9", "title": "How climate change affects daily weather"},
+        {"source": "doc10", "title": "The history of climate change activism"}
     ],
     ids=[
         "doc1",
@@ -115,6 +232,28 @@ collection.add(
     ]
 )
 
+def generate_summary(document_id, metadatas, documents):
+    # Lookup document text
+    doc_index = document_ids.index(document_id)
+    logging.info(f"meta_data gensummm: {metadatas}")
+    logging.info(f"documents: {documents}")
+    #doc_text = metadatas[doc_index]['text']
+    # Define the prompt for generating the summary
+    prompt = f"Summarize the following document:\n{documents}\n\nSummary:"
+
+    # Use the GPT-3 model to generate the summary
+    response = openai.Completion.create(
+        engine="davinci",
+        prompt=prompt,
+        max_tokens=50,  # Adjust the length of the summary as needed
+        stop=None,      # Allow the model to generate the summary freely
+        temperature=0.7  # Adjust the temperature for creativity
+    )
+
+    # Extract the generated summary from the response
+    summary = response.choices[0].text.strip()
+    
+    return summary
 
 # Main function
 if __name__ == "__main__":
@@ -125,11 +264,30 @@ if __name__ == "__main__":
     
     all_results = {}
     for query in generated_queries:
-        search_results = vector_search(query, collection)  # Use the modified vector_search() function
-        all_results[query] = search_results
+
+      #scores, score_values, document_ids = vector_search(query, collection)
+      scores, score_values, document_ids, metadatas, documents= vector_search(query, collection)
+
+      
+      all_results[query] = {
+        "scores": scores,
+        "score_values": score_values
+      }
     
-    reranked_results = reciprocal_rank_fusion(all_results)
+    logging.info(f"all_results: {all_results}")
+    logging.info(f"##############################################")
+    #reranked_results = reciprocal_rank_fusion(all_results)
+    reranked_results = reciprocal_rank_fusion(all_results, document_ids)
+    logging.info(f"##############################################")
+    print("Final reranked results <bottom>:", reranked_results)
+    logging.info(f"##############################################")    
     
-    final_output = generate_output(reranked_results, generated_queries)
+    #final_output = generate_output(reranked_results, generated_queries)
+    #final_output = generate_output(reranked_results, generated_queries, document_titles)
+    final_output = generate_output(reranked_results, generated_queries, metadatas, documents)
+    #final_output = generate_output(reranked_results, generated_queries, metadatas)
+
+
+
     
     print(final_output)

--- a/main.py
+++ b/main.py
@@ -2,19 +2,37 @@ import os
 import openai
 import random
 import chromadb
+import os
 
+# Set the TOKENIZERS_PARALLELISM environment variable
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-# Initialize OpenAI API
-openai.api_key = os.getenv("OPENAI_API_KEY")  # Alternative: Use environment variable
+# Now you can safely import tokenizers and the rest of your code
+#from transformers import AutoTokenizer
+
+# OpenAI API Initialization
+# Retrieve the OpenAI API key from the environment variables.
+# If the API key is not found, an exception is raised to alert the user.
+openai.api_key = os.getenv("OPENAI_API_KEY")
 if openai.api_key is None:
     raise Exception("No OpenAI API key found. Please set it as an environment variable or in main.py")
 
-# Initialize ChromeDB
+# Initialize the ChromaDB client
+# This client will be used to interact with the ChromaDB database.
 chroma_client = chromadb.Client()
 
 # Function to generate queries using OpenAI's ChatGPT
 def generate_queries_chatgpt(original_query):
-
+    """
+    Uses OpenAI's ChatGPT model to generate multiple related search queries from an original query.
+    
+    Parameters:
+    original_query (str): The initial query from which related queries will be generated.
+    
+    Returns:
+    list: A list of generated queries based on the original query.
+    """
+    # Call to OpenAI's API, specifying the ChatGPT model and the conversation flow to generate queries.
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
         messages=[
@@ -24,122 +42,155 @@ def generate_queries_chatgpt(original_query):
         ]
     )
 
+    # Parse the response to extract the generated queries and return them as a list.
     generated_queries = response.choices[0]["message"]["content"].strip().split("\n")
     return generated_queries
 
-# Function to perform a vector search, returning random scores
+# Function to perform a vector search within the ChromaDB collection
 def vector_search(query, collection):
+    """
+    Performs a vector search for a given query in the specified ChromaDB collection.
+    Assigns random relevance scores to the search results.
+    
+    Parameters:
+    query (str): The search query.
+    collection (chromadb.Collection): The ChromaDB collection to be searched.
+    
+    Returns:
+    tuple: A tuple containing the search results, score values, document IDs, metadata, and document texts.
+    """
+    # Query the collection using the provided search term.
+    chroma_results = collection.query(
+        query_texts=[query],  
+        n_results=4
+    )
+    
+    # Extract the document IDs from the search results.
+    document_ids = chroma_results['ids'][0]
 
-  # Perform vector search
-  chroma_results = collection.query(
-    query_texts=[query],  
-    n_results=4
-  )
-  
-  # Extract document IDs (flattened)
-  document_ids = chroma_results['ids'][0]  
+    # Initialize lists to store document texts and metadata.
+    chroma_doc_texts = []
+    chroma_doc_metadata = []
+    metadatas = []
+    documents = []  
 
-  # Retrieve documents
-  chroma_doc_texts = []
-  chroma_doc_metadata = []
-  # Initialize metadatas as a list
-  metadatas = []
-  documents = []  
+    # Retrieve and store the documents and metadata for each document ID.
+    for doc_id in document_ids:
+        doc_info = collection.get(ids=[doc_id])
 
-  for doc_id in document_ids:
-    doc_info = collection.get(ids=[doc_id])
+        if doc_info:
+            # Append the document text and metadata to their respective lists if found.
+            chroma_doc_texts.append(doc_info['documents'][0])
+            chroma_doc_metadata.append(doc_info['metadatas'][0])
+            metadata = doc_info['metadatas'][0] 
+            metadatas.append(metadata)
+            document = doc_info['documents'][0]
+            documents.append(document)
+        else:
+            # If the document is not found, append placeholders.
+            chroma_doc_texts.append("Document not found")
+            chroma_doc_metadata.append({})
 
-    if doc_info:
-      chroma_doc_texts.append(doc_info['documents'][0])
-      chroma_doc_metadata.append(doc_info['metadatas'][0])
-      metadata = doc_info['metadatas'][0] 
-      metadatas.append(metadata)
-      document = doc_info['documents'][0]
-      documents.append(document)
+    # Extract the document titles from the metadata.
+    document_titles = [metadata.get("title", "Unknown Title") for metadata in chroma_doc_metadata]
 
-    else:
-      chroma_doc_texts.append("Document not found")
-      chroma_doc_metadata.append({})
+    # Create a dictionary to hold the random scores assigned to each document.
+    scores_dict = {
+        doc_id: round(random.uniform(0.7, 0.9), 2) for doc_id in document_ids
+    }
+    
+    # Combine the document texts, titles, and scores into a single dictionary.
+    scores = {
+        "text": chroma_doc_texts,
+        "titles": document_titles, 
+        "scores": scores_dict
+    }
 
-  document_ids = chroma_results['ids'][0]
-  # Extract titles 
-  document_titles = [metadata.get("title", "Unknown Title") for metadata in chroma_doc_metadata]
+    # Convert the scores dictionary into a list of values.
+    score_values = list(scores_dict.values())
 
-  # Generate scores dict
-  scores_dict = {
-    doc_id: round(random.uniform(0.7, 0.9), 2) for doc_id in document_ids
-  }
-  # Create scores
-  scores = {
-    "text": chroma_doc_texts,
-    "titles": document_titles, 
-    "scores": scores_dict
-  }
-  # Extract just the score values into a list 
-  score_values = list(scores_dict.values())
-  # Also build documents list
-  #documents = [doc_info['documents'][0][0] for doc_info in collection.get(document_ids)]
+    return scores, score_values, document_ids, metadatas, documents
 
-  return scores, score_values, document_ids, metadatas, documents
-
-# Reciprocal Rank Fusion algorithm
+# Implementation of the Reciprocal Rank Fusion algorithm
 def reciprocal_rank_fusion(all_results, document_ids, k=60):
+    """
+    Applies the Reciprocal Rank Fusion (RRF) algorithm to combine multiple search result rankings.
+    
+    Parameters:
+    all_results (dict): A dictionary of search results keyed by query, each containing score values.
+    document_ids (list): A list of document IDs.
+    k (int, optional): The RRF parameter, used in the score calculation. Default is 60.
+    
+    Returns:
+    dict: A dictionary of reranked results with document IDs as keys and fused scores as values.
+    """
+    fused_scores = {}
 
-  fused_scores = {}
+    # Iterate through each set of results and apply the Reciprocal Rank Fusion (RRF) formula to calculate fused scores.
+    for query, result in all_results.items():
+        score_values = result["score_values"]
 
-  #for query, doc_scores in search_results_dict.items():
-  for query, result in all_results.items():
-    score_values = result["score_values"]
+        for rank, score in enumerate(sorted(score_values)):
+            doc_id = document_ids[rank]
+            if doc_id not in fused_scores:
+                fused_scores[doc_id] = 0
+            previous_score = fused_scores[doc_id]
+            fused_scores[doc_id] += 1 / (rank + k)
 
-    for rank, score in enumerate(sorted(score_values)):    
-      doc_id = document_ids[rank]      
-      if doc_id not in fused_scores:
-        fused_scores[doc_id] = 0        
-      previous_score = fused_scores[doc_id]      
-      fused_scores[doc_id] += 1 / (rank + k)
+    # Sort the fused scores in descending order to rerank the results.
+    reranked_results = {doc_id: score for doc_id, score in sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)}
+    
+    print("Final reranked results:", reranked_results)
 
-  reranked_results = {doc_id: score for doc_id, score in sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)}
-  
-  print("Final reranked results:", reranked_results)
+    return reranked_results
 
-  return reranked_results
-
+# Function to generate a final output that includes the most relevant document
 def generate_output(reranked_results, queries, metadatas, documents):
-    # Extract the top-ranked document ID and its score
+    """
+    Generates a detailed output from the reranked results, including the top document's title, score, and summary.
+    
+    Parameters:
+    reranked_results (dict): The reranked results from the RRF algorithm.
+    queries (list): The list of original queries.
+    metadatas (list): The list of metadata for documents.
+    documents (list): The list of document texts.
+    
+    Returns:
+    str: A string containing a formatted response with the search results.
+    """
+    # Find the top-ranked document and its score.
     top_document_id, top_score = next(iter(reranked_results.items()))
 
-    # Fetch the actual document title associated with the document ID 
+    # Find the index of the top document in the list of document IDs.
     top_doc_index = document_ids.index(top_document_id)
+    # Retrieve the metadata for the top-ranked document.
     top_doc_metadata = metadatas[top_doc_index]
+    # Get the title from the metadata, defaulting to "Unknown Title" if not present.
     top_document_title = top_doc_metadata.get("title", "Unknown Title")
 
-    # Generate_summary() generates a summary for the top document
-    document_summary = generate_summary(top_document_id, metadatas, documents)  # Implement this function
+    # Call the function to generate a summary for the top document.
+    document_summary = generate_summary(top_document_id, metadatas, documents)
 
-    # Generate a response with the correct document title, relevance score, summary, and original queries
+    # Construct the final response string with the document title, score, summary, and original queries.
     response = f"Here is the most relevant information regarding '{queries[0]}':\n\n"
     response += f"Document Title: {top_document_title}\n"
     response += f"Relevance Score: {top_score}\n\n"
     response += f"Summary of the document:\n{document_summary}\n\n"
 
+    # Append the original queries to the response.
     response += "Original Queries:\n"
     for query in queries:
         response += f"- {query}\n"
 
+    # Add a concluding statement about the technologies used in this script.
     response += "\nBy layering these technologies and techniques, RAG Fusion offers a powerful, nuanced approach to text generation. It leverages the best of search technology and generative AI to produce high-quality, reliable outputs."
 
     return response
 
-# Chroma: Create Collection in this case "all_documents"
+# Create a new collection within ChromaDB named "all_documents".
 collection = chroma_client.create_collection(name="all_documents")
 
-#################################
-# Predefined set of documents (usually these would be from your search database)
-## Replaced the "all_documents" section with the below chroma collection.
-#################################
-
-#Added some text documents to the collection
-#Chroma will store your text, and handle tokenization, embedding, and indexing automatically.
+# Add a predefined set of documents related to climate change to the collection, along with their metadata.
 collection.add(
     documents=[
         "Climate change and economic impact. Addressing climate change can be challenging, but by investing in sustainable technologies and policies, we can mitigate its economic impact and build a greener, more resilient future.",
@@ -179,14 +230,25 @@ collection.add(
     ]
 )
 
+# Function to generate a summary for a given document
 def generate_summary(document_id, metadatas, documents):
-    # Lookup document text
+    """
+    Generates a summary for a specified document using OpenAI's GPT-3 model.
+    
+    Parameters:
+    document_id (str): The ID of the document to summarize.
+    metadatas (list): The list of metadata for documents.
+    documents (list): The list of document texts.
+    
+    Returns:
+    str: The generated summary for the document.
+    """
+    # Find the index of the document using its ID.
     doc_index = document_ids.index(document_id)
+    # Construct the prompt for the summary generation.
+    prompt = f"Summarize the following document:\n{documents[doc_index]}\n\nSummary:"
 
-    # Define the prompt for generating the summary
-    prompt = f"Summarize the following document:\n{documents}\n\nSummary:"
-
-    # Use the GPT-3 model to generate the summary
+    # Generate the summary using OpenAI's model.
     response = openai.Completion.create(
         engine="davinci",
         prompt=prompt,
@@ -195,29 +257,29 @@ def generate_summary(document_id, metadatas, documents):
         temperature=0.7  # Adjust the temperature for creativity
     )
 
-    # Extract the generated summary from the response
-    summary = response.choices[0].text.strip()    
+    # Extract and return the summary from the response.
+    summary = response.choices[0].text.strip()
     return summary
 
-# Main function
+# Main function to be executed when the script is run
 if __name__ == "__main__":
-    # Define your Chroma collection and other necessary configurations here
+    # Example query to kickstart the process.
     original_query = "impact of climate change"
     generated_queries = generate_queries_chatgpt(original_query)
     
+    # Perform vector searches and store results.
     all_results = {}
     for query in generated_queries:
-
-      scores, score_values, document_ids, metadatas, documents= vector_search(query, collection)
-      
-      all_results[query] = {
-        "scores": scores,
-        "score_values": score_values
-      }
+        scores, score_values, document_ids, metadatas, documents = vector_search(query, collection)
+        all_results[query] = {
+            "scores": scores,
+            "score_values": score_values
+        }
     
+    # Apply reciprocal rank fusion to the collected results.
     reranked_results = reciprocal_rank_fusion(all_results, document_ids)
-    print("Final reranked results <bottom>:", reranked_results)  
+    print("Final reranked results <bottom>:", reranked_results)
     
+    # Generate the final output and print it.
     final_output = generate_output(reranked_results, generated_queries, metadatas, documents)
-    
     print(final_output)


### PR DESCRIPTION
Implement vector search using Chroma DB, this was the first one I found that I could quickly understand.
I expect it is notional and will later support any vector database.

- Initialize Chroma client and collection
- Add documents to Chroma collection
- Update vector_search() to query Chroma
- Perform vector query
- Extract document IDs, text, metadata
- Build scores with random values
- Update reciprocal_rank_fusion()
- Take document IDs to map ranks back
- Use score values instead of full scores dict
- Pass metadatas and documents through pipeline
- Return metadatas from vector_search()
- Pass metadatas to generate_output()
- Update generate_output()
- Lookup metadata by document index
- Get document text from documents list
- Add logging for debugging and transparency

This migrates vector search from random mock data to using the Chroma database. Document text and metadata are retrieved from Chroma and passed through the pipeline. Additional logging provides visibility into the process. Reciprocal rank fusion is updated to work with the Chroma results structure.

Update improves the backend search functionality using a real vector database, while preserving the existing pipeline structure.


TODO:
Better understand vector search to remove "random"
Remove logging
Refactor the functions now that they are larger.